### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,9 +5,5 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
-      version = "~> 1.0.4"
-    }
   }
 }


### PR DESCRIPTION
Closes #4

Removes the vestigial `azurenoops/azurenoopsutils` provider declaration from `versions.tf`. This module is pure HCL locals for Azure region name lookups and has no provider dependencies beyond `hashicorp/azurerm`.

**Changes:**
- `versions.tf`: deleted 4-line `azurenoopsutils` block from `required_providers`

**Validation:**
- `terraform init -backend=false` ✅
- `terraform validate` ✅  
- `terraform providers` lists only `hashicorp/azurerm` ✅
- Zero `azurenoops` refs in all file types ✅
- `tests/main` validates cleanly ✅